### PR TITLE
remove unused per file ignores

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,10 +21,6 @@ per-file-ignores =
     test/*:FA100
     test/typing/plain_files/*:F821,E501,FA100
     lib/sqlalchemy/events.py:F401
-    lib/sqlalchemy/schema.py:F401
-    lib/sqlalchemy/types.py:F401
-    lib/sqlalchemy/sql/expression.py:F401
-    lib/sqlalchemy/util/typing.py:F401
 
 unused-arguments-ignore-stub-functions=true
 unused-arguments-ignore-dunder=true


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
Because of this per file ignored, the unused ignored on lib/sqlalchemy/util/typing was not detected.
I guess that on init and on event are needed, but the others are not doing anythong after your PR.+

### Description
<!-- Describe your changes in detail -->
Remove ignores of unused imports on files that dont have unused imports

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
